### PR TITLE
Remove the mm table TCA

### DIFF
--- a/Configuration/TCA/Overrides/tx_faq_mm_question_questioncategory.php
+++ b/Configuration/TCA/Overrides/tx_faq_mm_question_questioncategory.php
@@ -1,21 +1,3 @@
 <?php
 
-/**
- * Base TCA generation for the table tx_faq_mm_question_questioncategory
- */
-
-$GLOBALS['TCA']['tx_faq_mm_question_questioncategory'] = \HDNET\Autoloader\Utility\ModelUtility::getTcaOverrideInformation(
-    'faq',
-    'tx_faq_mm_question_questioncategory'
-);
-
-$custom = [
-    'ctrl' => [
-        'hideTable' => true,
-    ],
-];
-
-$GLOBALS['TCA']['tx_faq_mm_question_questioncategory'] = \HDNET\Autoloader\Utility\ArrayUtility::mergeRecursiveDistinct(
-    $GLOBALS['TCA']['tx_faq_mm_question_questioncategory'],
-    $custom
-);
+// Don't do anything, but prevent the autoloader from creating this file.


### PR DESCRIPTION
This patch (https://github.com/TYPO3/TYPO3.CMS/commit/65a9d8a7a423979777d2c4634565ae690dc477be)
removed a core check for the "pid" field on a table. The core now only checks for the
TCA. If it finds TCA it will add the pid clause.

I think we don't need the TCA at all and it is only an autoloader artifact.