### PR TITLE
[TASK] added Doctrine IgnoreAnnotation Notations

### DIFF
--- a/Classes/Controller/FaqController.php
+++ b/Classes/Controller/FaqController.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * FAQ
  *
+ * @IgnoreAnnotation("cache")
+ * @IgnoreAnnotation("donotvalidate")
  */
 class FaqController extends AbstractController
 {


### PR DESCRIPTION
due to errors in TYPO3 9.5, the Annotations @cache and @donotvalidate cause Doctrine AnnotationExceptions.