### PR TITLE
Adapt ext config to match composer.json TYPO3 dependencies.

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends'   => [
             'php' => '7.2.0-7.4.99',
             'autoloader' => '7.0.0-7.99.99',
-            'typo3'      => '10.0.0-11.99.99',
+            'typo3'      => '11.5.0-11.99.99',
         ],
         'conflicts' => [],
         'suggests'  => [],


### PR DESCRIPTION
- According to the composer.json you need to have at least TYPO3 11.5.
- Now the ext_emconf.php also reflects this requirement.