### PR TITLE
[TASK] add htmlentities to SchemaService

### DIFF
--- a/Classes/Service/SchemaService.php
+++ b/Classes/Service/SchemaService.php
@@ -24,9 +24,9 @@ class SchemaService
                 'ANSWER_TEXT',
             ],
                 [
-                    $question->getTitle(),
+                    htmlentities($question->getTitle()),
                     $question->getCrdate()->format('Y-m-d H:i:s'),
-                    strip_tags($question->getAnswer()),
+                    htmlentities(\strip_tags($question->getAnswer())),
                 ],
                 '{
                 "@type": "Question",


### PR DESCRIPTION
If a title or text contains quotes, the schema is not valid. In this case, I've added HTML entities around the stripped content and the title.